### PR TITLE
Fix/update main.zig

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -3,17 +3,17 @@ const Tokenizer = @import("tokenizer.zig").Tokenizer;
 
 pub const log_level: std.log.Level = .debug;
 
-pub fn main() !void { 
+pub fn main() !void {
     var alloc = std.heap.page_allocator;
-    var tokenizer = try Tokenizer.initWithFile(alloc, "./test.html");
+    var tokenizer = try Tokenizer.initWithFile(alloc, "test.html");
     while (true) {
-        var token = tokenizer.next() catch |err| {
+        var token = tokenizer.nextToken() catch |err| {
             std.log.err(.main, "{} at line: {}, column: {}\n", .{ err, tokenizer.line, tokenizer.column });
             continue;
         };
 
         if (token) |tok| {
-            std.log.info(.main, "{}\n", .{ tok });
+            std.log.info(.main, "{}\n", .{tok});
             if (tok == .EndOfFile) break;
         }
     }


### PR DESCRIPTION
- Tokenizer.next was renamed to Tokenizer.nextToken in 7a7b2b51e94fdf5aecf836e97989ca79dbb5efb5
- Removes the ./ from the path to test.html to make it work on Windows
- Formatting changes are coming from `zig fmt`