### PR TITLE
Fix reconsuming the last character of a file

### DIFF
--- a/src/tokenizer.zig
+++ b/src/tokenizer.zig
@@ -1809,8 +1809,9 @@ pub const Tokenizer = struct {
     }
 
     pub fn eof(self: Self) bool {
-        if (self.index >= self.contents.len) return true;
-        return false;
+        // if we're reconsuming, then we can still read the last character
+        const max_index = if (self.reconsume) self.contents.len else self.contents.len - 1;
+        return self.index > max_index;
     }
 
     pub fn emitToken(self: *Self, token: Token) void {


### PR DESCRIPTION
eof would previously return true when at the last character of a file even when that character would be reconsumed, leading to failing to emit the last token in certain cases (e.g. a file with only "<>" would fail to emit the ">")

---

I know you said to hold off on fixes but I couldn't resist. This might be obsoleted by more robust EOF handling, but it fixes quite a few failing html5lib tests in the meantime.