### PR TITLE
Fix various token construction issues

### DIFF
--- a/src/token.zig
+++ b/src/token.zig
@@ -33,7 +33,9 @@ pub const Token = union(enum) {
     },
     EndTag: struct {
         name: ?[]const u8 = null,
+        /// Ignored past tokenization, only used for errors
         selfClosing: bool = false,
+        /// Ignored past tokenization, only used for errors
         attributes: StringHashMap([]const u8),
 
         pub fn format(value: @This(), comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: var) !void {
@@ -59,9 +61,4 @@ pub const Token = union(enum) {
         }
     },
     EndOfFile,
-
-    pub const Attribute = struct {
-        name:  []const u8,
-        value: []const u8,
-    };
 };


### PR DESCRIPTION
- Adds IncompleteToken which consolidates the logic for constructing token data to one place
  + Also makes the logic within the switch statements more closely match the language in the spec, since data is appended to buffers in Tokenizer.currentToken
- Adds support for lastEmittedStartTag which allows implementing the various EndTagName states
- Now passes test1-test4 of html5lib-tests if all tests with inputs containing \r, &, or multi-byte codepoints are excluded
  + I was just manually removing the unhandled test cases, here's a zip with the failing tests removed: [working-tokenizer-tests.zip](https://github.com/watzon/zhtml/files/4923760/working-tokenizer-tests.zip). The `.test` files in that zip should all pass after this PR.

---

I will be creating issues for the remaining tokenizer problems as I understand them